### PR TITLE
choose を使わない例を示す

### DIFF
--- a/Examples/Choose.lean
+++ b/Examples/Choose.lean
@@ -14,3 +14,24 @@ example (f : X → Y) (hf : ∀ y, ∃ x, f x = y) : ∃ g : Y → X, ∀ y, f (
 
   exact ⟨g, hg⟩
 -- ANCHOR_END: first
+
+
+-- ANCHOR: no_choose
+variable (P : X → Y → Prop)
+
+noncomputable example (h : ∀ x, ∃ y, P x y) : ∃ f : X → Y, ∀ x, P x (f x) := by
+  -- `f` を作る
+  let f' : (x : X) → {y // P x y} := fun x ↦
+    have hne_st : Nonempty {y // P x y} :=
+      let ⟨y, py⟩ := h x; ⟨⟨y, py⟩⟩
+    Classical.choice hne_st
+
+  let f : X → Y := fun x ↦ (f' x).val
+
+  -- 上記で作った関数が条件を満たすことを示す
+  have h₁ : ∀ x, P x (f x) := by
+    intro x
+    exact (f' x).property
+
+  exists f
+-- ANCHOR_END: no_choose

--- a/src/choose.md
+++ b/src/choose.md
@@ -7,3 +7,11 @@ needs: `import Mathlib.Tactic.Choose`
 ```lean
 {{#include ../Examples/Choose.lean:first}}
 ```
+
+## 補足
+
+`choose` が自動で示してくれることは選択公理 `Classical.choice` を使って手動で示すことができます．たとえば次のようになります．
+
+```lean
+{{#include ../Examples/Choose.lean:no_choose}}
+```

--- a/src/choose.md
+++ b/src/choose.md
@@ -10,7 +10,7 @@ needs: `import Mathlib.Tactic.Choose`
 
 ## 補足
 
-`choose` が自動で示してくれることは選択公理 `Classical.choice` を使って手動で示すことができます．たとえば次のようになります．
+`choose` が自動で示してくれることは選択原理 `Classical.choice` を使って手動で示すことができます．たとえば次のようになります．
 
 ```lean
 {{#include ../Examples/Choose.lean:no_choose}}


### PR DESCRIPTION
@Seasawher 

#4 と#5 を受けて作成したPRです。
#4 と同様の変更内容をaconite名義でcommitし、
また`choose.md`内の「選択公理」という記述を「選択原理」に置換しました。